### PR TITLE
override toString for JsonMedia

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.github.sebastian-toepfer.ddd</groupId>
         <artifactId>domain-driven-desgin</artifactId>
-        <version>0.1.1</version>
+        <version>0.1.2</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/media-core/pom.xml
+++ b/media-core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.github.sebastian-toepfer.ddd</groupId>
         <artifactId>domain-driven-desgin</artifactId>
-        <version>0.1.1</version>
+        <version>0.1.2</version>
     </parent>
 
     <artifactId>media-core</artifactId>

--- a/media-json-api/pom.xml
+++ b/media-json-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.github.sebastian-toepfer.ddd</groupId>
         <artifactId>domain-driven-desgin</artifactId>
-        <version>0.1.1</version>
+        <version>0.1.2</version>
     </parent>
 
     <artifactId>media-json-api</artifactId>

--- a/media-json-api/src/main/java/io/github/sebastiantoepfer/ddd/media/json/JsonObjectMedia.java
+++ b/media-json-api/src/main/java/io/github/sebastiantoepfer/ddd/media/json/JsonObjectMedia.java
@@ -115,6 +115,11 @@ public class JsonObjectMedia extends AbstractMap<String, JsonValue> implements M
     }
 
     @Override
+    public String toString() {
+        return json.toString();
+    }
+
+    @Override
     public JsonArray getJsonArray(final String string) {
         return json.getJsonArray(string);
     }

--- a/media-json-api/src/test/java/io/github/sebastiantoepfer/ddd/media/json/JsonObjectMediaTest.java
+++ b/media-json-api/src/test/java/io/github/sebastiantoepfer/ddd/media/json/JsonObjectMediaTest.java
@@ -181,4 +181,12 @@ class JsonObjectMediaTest {
         assertThat(media.getBoolean("other_boolean", Boolean.FALSE), is(false));
         assertThat(media.getBoolean("other_boolean", Boolean.TRUE), is(true));
     }
+
+    @Test
+    void should_generate_correct_jsonstring() {
+        assertThat(
+            new JsonObjectMedia().withValue("name", "name").toString(),
+            is(Json.createObjectBuilder().add("name", "name").build().toString())
+        );
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.sebastian-toepfer.ddd</groupId>
     <artifactId>domain-driven-desgin</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
 
     <name>Domain Driven Desgin</name>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,8 @@
         <sonar.organization>sebastian-toepfer</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
+        <nexusUrl>https://s01.oss.sonatype.org</nexusUrl>
+
         <prettier.goal>write</prettier.goal>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -365,6 +367,17 @@
                         </execution>
                     </executions>
                 </plugin>
+
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.13</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <serverId>ossrh</serverId>
+                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -406,6 +419,10 @@
 
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
@@ -516,11 +533,11 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <url>${nexusUrl}/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
             <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>${nexusUrl}/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 </project>


### PR DESCRIPTION
media is also an object where toString can be used to create a valid jsonstring. but jsonmedia also implements a map and thus toString must explicitly use our generated json here