### PR TITLE
extends slf4jmedia to override name in mdc

### DIFF
--- a/media-logging-slf4j/pom.xml
+++ b/media-logging-slf4j/pom.xml
@@ -42,6 +42,14 @@
         </dependency>
 
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>media-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
until this change the name in the mdc was the same as the name of the property e.g. the property was name the mdcname was name.
now it is possible to override this by providing a map instead of a list. Map.of("name", "username") and the property name will get username as it's mdcname