### PR TITLE
replace writer with outputstream in writebale

### DIFF
--- a/media-core/pom.xml
+++ b/media-core/pom.xml
@@ -22,6 +22,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/media-core/src/main/java/io/github/sebastiantoepfer/ddd/media/core/BytesWritebale.java
+++ b/media-core/src/main/java/io/github/sebastiantoepfer/ddd/media/core/BytesWritebale.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2023 sebastian.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.sebastiantoepfer.ddd.media.core;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Objects;
+
+class BytesWritebale {
+
+    private final Writeable writable;
+
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP2")
+    public BytesWritebale(final Writeable writable) {
+        this.writable = Objects.requireNonNull(writable);
+    }
+
+    public byte[] asBytes() throws IOException {
+        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            writable.writeTo(baos);
+            return baos.toByteArray();
+        }
+    }
+}

--- a/media-core/src/main/java/io/github/sebastiantoepfer/ddd/media/core/StringWriteable.java
+++ b/media-core/src/main/java/io/github/sebastiantoepfer/ddd/media/core/StringWriteable.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2023 sebastian.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.sebastiantoepfer.ddd.media.core;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+class StringWriteable {
+
+    private final BytesWritebale bytes;
+
+    public StringWriteable(final Writeable writable) {
+        bytes = new BytesWritebale(writable);
+    }
+
+    public String asString() throws IOException {
+        try (
+            BufferedReader br = new BufferedReader(
+                new InputStreamReader(new ByteArrayInputStream(bytes.asBytes()), StandardCharsets.UTF_8)
+            )
+        ) {
+            return br.lines().collect(Collectors.joining("\n"));
+        }
+    }
+}

--- a/media-core/src/main/java/io/github/sebastiantoepfer/ddd/media/core/Writeable.java
+++ b/media-core/src/main/java/io/github/sebastiantoepfer/ddd/media/core/Writeable.java
@@ -1,8 +1,16 @@
 package io.github.sebastiantoepfer.ddd.media.core;
 
 import java.io.IOException;
-import java.io.Writer;
+import java.io.OutputStream;
 
 public interface Writeable {
-    Writer writeTo(Writer write) throws IOException;
+    void writeTo(OutputStream output) throws IOException;
+
+    default String asString() throws IOException {
+        return new StringWriteable(this).asString();
+    }
+
+    default byte[] asBytes() throws IOException {
+        return new BytesWritebale(this).asBytes();
+    }
 }

--- a/media-core/src/test/java/io/github/sebastiantoepfer/ddd/media/core/WriteableTest.java
+++ b/media-core/src/test/java/io/github/sebastiantoepfer/ddd/media/core/WriteableTest.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2023 sebastian.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.sebastiantoepfer.ddd.media.core;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import org.junit.jupiter.api.Test;
+
+class WriteableTest {
+
+    @Test
+    void should_create_as_byte_array() throws IOException {
+        assertThat(
+            new Writeable() {
+                @Override
+                public void writeTo(final OutputStream output) throws IOException {
+                    output.write(0x01);
+                }
+            }
+                .asBytes(),
+            is(new byte[] { 0x01 })
+        );
+    }
+
+    @Test
+    void should_create_as_string() throws IOException {
+        assertThat(
+            new Writeable() {
+                @Override
+                public void writeTo(final OutputStream output) throws IOException {
+                    output.write("hello".getBytes());
+                }
+            }
+                .asString(),
+            is("hello")
+        );
+    }
+}

--- a/media-logging-slf4j/src/main/java/io/github/sebastiantoepfer/ddd/media/logging/slf4j/FixedLogLevel.java
+++ b/media-logging-slf4j/src/main/java/io/github/sebastiantoepfer/ddd/media/logging/slf4j/FixedLogLevel.java
@@ -5,7 +5,6 @@ import io.github.sebastiantoepfer.ddd.media.logging.CanNotLog;
 import io.github.sebastiantoepfer.ddd.media.logging.LogEntry;
 import io.github.sebastiantoepfer.ddd.media.logging.LogLevelDecision;
 import java.io.IOException;
-import java.io.StringWriter;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
 
@@ -43,9 +42,8 @@ class FixedLogLevel implements LogLevelDecision<Logger> {
         }
 
         private String logmessage() {
-            try (final StringWriter sw = new StringWriter()) {
-                writeable.writeTo(sw);
-                return sw.getBuffer().toString();
+            try {
+                return writeable.asString();
             } catch (IOException e) {
                 throw new CanNotLog(e);
             }

--- a/media-logging/src/main/java/io/github/sebastiantoepfer/ddd/media/logging/jul/JULogEntry.java
+++ b/media-logging/src/main/java/io/github/sebastiantoepfer/ddd/media/logging/jul/JULogEntry.java
@@ -4,7 +4,6 @@ import io.github.sebastiantoepfer.ddd.media.core.Writeable;
 import io.github.sebastiantoepfer.ddd.media.logging.CanNotLog;
 import io.github.sebastiantoepfer.ddd.media.logging.LogEntry;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -22,8 +21,8 @@ class JULogEntry implements LogEntry<Logger> {
 
     @Override
     public void logTo(final Logger logger) {
-        try (final StringWriter sw = new StringWriter()) {
-            final LogRecord logRecord = new LogRecord(level, message.writeTo(sw).toString());
+        try {
+            final LogRecord logRecord = new LogRecord(level, message.asString());
             logRecord.setLoggerName(logger.getName());
             logRecord.setSourceClassName(logger.getName());
             logger.log(logRecord);

--- a/media-message/src/main/java/io/github/sebastiantoepfer/ddd/media/message/MessageMedia.java
+++ b/media-message/src/main/java/io/github/sebastiantoepfer/ddd/media/message/MessageMedia.java
@@ -8,9 +8,12 @@ import io.github.sebastiantoepfer.ddd.media.core.HashMapMedia;
 import io.github.sebastiantoepfer.ddd.media.core.Writeable;
 import io.github.sebastiantoepfer.ddd.media.core.utils.CopyMap;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -30,9 +33,10 @@ public class MessageMedia implements Media<MessageMedia>, Writeable {
     }
 
     @Override
-    public final Writer writeTo(final Writer write) throws IOException {
-        write.write(format.format(map));
-        return write;
+    public final void writeTo(final OutputStream write) throws IOException {
+        final Writer osw = new OutputStreamWriter(write, StandardCharsets.UTF_8);
+        osw.write(format.format(map));
+        osw.flush();
     }
 
     @Override

--- a/media-message/src/main/java/io/github/sebastiantoepfer/ddd/media/message/MessageMediaExtension.java
+++ b/media-message/src/main/java/io/github/sebastiantoepfer/ddd/media/message/MessageMediaExtension.java
@@ -5,7 +5,7 @@ import io.github.sebastiantoepfer.ddd.common.Media;
 import io.github.sebastiantoepfer.ddd.common.Printable;
 import io.github.sebastiantoepfer.ddd.media.core.Writeable;
 import java.io.IOException;
-import java.io.Writer;
+import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collection;
@@ -71,8 +71,8 @@ public abstract class MessageMediaExtension<T extends MessageMediaExtension<T>> 
     }
 
     @Override
-    public final Writer writeTo(final Writer write) throws IOException {
-        return media.writeTo(write);
+    public final void writeTo(final OutputStream write) throws IOException {
+        media.writeTo(write);
     }
 
     protected abstract T createWith(final MessageMedia message);

--- a/media-message/src/test/java/io/github/sebastiantoepfer/ddd/media/message/MessageMediaExtensionTest.java
+++ b/media-message/src/test/java/io/github/sebastiantoepfer/ddd/media/message/MessageMediaExtensionTest.java
@@ -1,12 +1,16 @@
 package io.github.sebastiantoepfer.ddd.media.message;
 
+import static java.util.stream.Collectors.joining;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 import io.github.sebastiantoepfer.ddd.media.core.TestPrintable;
-import java.io.StringWriter;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStreamReader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
@@ -42,8 +46,15 @@ class MessageMediaExtensionTest {
             .withValue("person", new TestPrintable(Map.of("firstname", "Joe", "lastname", "Doe")))
             .withValue("list", List.of("bananas", "apples"));
 
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        message.writeTo(baos);
+        final String msg = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(baos.toByteArray())))
+            .lines()
+            .collect(joining("\n")) +
+        "\n";
+
         assertThat(
-            message.writeTo(new StringWriter()).toString(),
+            msg,
             is(
                 """
                 Hello my name is Jane and i am 42 years old.

--- a/media-message/src/test/java/io/github/sebastiantoepfer/ddd/media/message/MessageMediaTest.java
+++ b/media-message/src/test/java/io/github/sebastiantoepfer/ddd/media/message/MessageMediaTest.java
@@ -1,10 +1,15 @@
 package io.github.sebastiantoepfer.ddd.media.message;
 
+import static java.util.stream.Collectors.joining;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.is;
 
 import io.github.sebastiantoepfer.ddd.media.core.TestPrintable;
-import java.io.StringWriter;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStreamReader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.MessageFormat;
@@ -17,157 +22,195 @@ class MessageMediaTest {
 
     @Test
     void should_format_with_strings() throws Exception {
-        assertThat(
-            new MessageMedia(
-                new MessageFormatNamedBridge(
-                    new MessageFormat("Hello Mr. {0} {1}!"),
-                    Map.of("firstName", 0, "lastName", 1)
-                )
-            )
-                .withValue("lastName", "Doe")
-                .withValue("firstName", "John")
-                .writeTo(new StringWriter()),
-            hasToString("Hello Mr. John Doe!")
-        );
+        final MessageMedia media = new MessageMedia(
+            new MessageFormatNamedBridge(new MessageFormat("Hello Mr. {0} {1}!"), Map.of("firstName", 0, "lastName", 1))
+        )
+            .withValue("lastName", "Doe")
+            .withValue("firstName", "John");
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        media.writeTo(baos);
+        final String message = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(baos.toByteArray())))
+            .lines()
+            .collect(joining("\n"));
+
+        assertThat(message, hasToString("Hello Mr. John Doe!"));
     }
 
     @Test
     void should_format_with_int() throws Exception {
-        assertThat(
-            new MessageMedia(
-                new MessageFormatNamedBridge(
-                    new MessageFormat("The disk \"{1}\" contains {0, number} file(s)."),
-                    Map.of("diskName", 1, "fileCount", 0)
-                )
+        final MessageMedia media = new MessageMedia(
+            new MessageFormatNamedBridge(
+                new MessageFormat("The disk \"{1}\" contains {0, number} file(s)."),
+                Map.of("diskName", 1, "fileCount", 0)
             )
-                .withValue("diskName", "MyDisk")
-                .withValue("fileCount", 10)
-                .writeTo(new StringWriter()),
-            hasToString("The disk \"MyDisk\" contains 10 file(s).")
-        );
+        )
+            .withValue("diskName", "MyDisk")
+            .withValue("fileCount", 10);
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        media.writeTo(baos);
+        final String message = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(baos.toByteArray())))
+            .lines()
+            .collect(joining("\n"));
+
+        assertThat(message, hasToString("The disk \"MyDisk\" contains 10 file(s)."));
     }
 
     @Test
     void should_format_with_long() throws Exception {
-        assertThat(
-            new MessageMedia(
-                new MessageFormatNamedBridge(
-                    new MessageFormat("The disk \"{1}\" contains {0, number} file(s).", Locale.GERMANY),
-                    Map.of("diskName", 1, "fileCount", 0)
-                )
+        final MessageMedia media = new MessageMedia(
+            new MessageFormatNamedBridge(
+                new MessageFormat("The disk \"{1}\" contains {0, number} file(s).", Locale.GERMANY),
+                Map.of("diskName", 1, "fileCount", 0)
             )
-                .withValue("diskName", "MyDisk")
-                .withValue("fileCount", 1273L)
-                .writeTo(new StringWriter()),
-            hasToString("The disk \"MyDisk\" contains 1.273 file(s).")
-        );
+        )
+            .withValue("diskName", "MyDisk")
+            .withValue("fileCount", 1273L);
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        media.writeTo(baos);
+        final String message = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(baos.toByteArray())))
+            .lines()
+            .collect(joining("\n"));
+
+        assertThat(message, hasToString("The disk \"MyDisk\" contains 1.273 file(s)."));
     }
 
     @Test
     void should_format_with_doubles() throws Exception {
-        assertThat(
-            new MessageMedia(
-                new MessageFormatNamedBridge(
-                    new MessageFormat("{0,number,#.##}, {0,number,#.#}", Locale.GERMANY),
-                    Map.of("pi", 0)
-                )
+        final MessageMedia media = new MessageMedia(
+            new MessageFormatNamedBridge(
+                new MessageFormat("{0,number,#.##}, {0,number,#.#}", Locale.GERMANY),
+                Map.of("pi", 0)
             )
-                .withValue("pi", 3.1415)
-                .writeTo(new StringWriter()),
-            hasToString("3,14, 3,1")
-        );
+        )
+            .withValue("pi", 3.1415);
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        media.writeTo(baos);
+        final String message = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(baos.toByteArray())))
+            .lines()
+            .collect(joining("\n"));
+
+        assertThat(message, hasToString("3,14, 3,1"));
     }
 
     @Test
     void should_format_with_bigdecimal() throws Exception {
-        assertThat(
-            new MessageMedia(
-                new MessageFormatNamedBridge(
-                    new MessageFormat("{0,number,#.##}, {0,number,#.#}", Locale.GERMANY),
-                    Map.of("pi", 0)
-                )
+        final MessageMedia media = new MessageMedia(
+            new MessageFormatNamedBridge(
+                new MessageFormat("{0,number,#.##}, {0,number,#.#}", Locale.GERMANY),
+                Map.of("pi", 0)
             )
-                .withValue("pi", BigDecimal.valueOf(3.1415))
-                .writeTo(new StringWriter()),
-            hasToString("3,14, 3,1")
-        );
+        )
+            .withValue("pi", BigDecimal.valueOf(3.1415));
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        media.writeTo(baos);
+        final String message = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(baos.toByteArray())))
+            .lines()
+            .collect(joining("\n"));
+
+        assertThat(message, hasToString("3,14, 3,1"));
     }
 
     @Test
     void should_format_with_biginteger() throws Exception {
-        assertThat(
-            new MessageMedia(
-                new MessageFormatNamedBridge(
-                    new MessageFormat("The disk \"{1}\" contains {0, number} file(s).", Locale.US),
-                    Map.of("diskName", 1, "fileCount", 0)
-                )
+        final MessageMedia media = new MessageMedia(
+            new MessageFormatNamedBridge(
+                new MessageFormat("The disk \"{1}\" contains {0, number} file(s).", Locale.US),
+                Map.of("diskName", 1, "fileCount", 0)
             )
-                .withValue("diskName", "MyDisk")
-                .withValue("fileCount", BigInteger.valueOf(8771242817265172523L))
-                .writeTo(new StringWriter()),
-            hasToString("The disk \"MyDisk\" contains 8,771,242,817,265,172,523 file(s).")
-        );
+        )
+            .withValue("diskName", "MyDisk")
+            .withValue("fileCount", BigInteger.valueOf(8771242817265172523L));
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        media.writeTo(baos);
+        final String message = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(baos.toByteArray())))
+            .lines()
+            .collect(joining("\n"));
+
+        assertThat(message, hasToString("The disk \"MyDisk\" contains 8,771,242,817,265,172,523 file(s)."));
     }
 
     @Test
     void should_format_with_boolean() throws Exception {
-        assertThat(
-            new MessageMedia(new MessageFormatNamedBridge(new MessageFormat("Was {0}."), Map.of("successful", 0)))
-                .withValue("successful", true)
-                .writeTo(new StringWriter()),
-            hasToString("Was true.")
-        );
+        final MessageMedia media = new MessageMedia(
+            new MessageFormatNamedBridge(new MessageFormat("Was {0}."), Map.of("successful", 0))
+        )
+            .withValue("successful", true);
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        media.writeTo(baos);
+        final String message = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(baos.toByteArray())))
+            .lines()
+            .collect(joining("\n"));
+
+        assertThat(message, is("Was true."));
     }
 
     @Test
     void should_format_with_printable() throws Exception {
         //we use sal to catch a mutant -> we need a string shorter than "person."
-        assertThat(
-            new MessageMedia(
-                new MessageFormatNamedBridge(
-                    new MessageFormat("Hello {0} {1} {2}."),
-                    Map.of("sal", 0, "person.lastName", 2, "person.firstName", 1)
-                )
+        final MessageMedia media = new MessageMedia(
+            new MessageFormatNamedBridge(
+                new MessageFormat("Hello {0} {1} {2}."),
+                Map.of("sal", 0, "person.lastName", 2, "person.firstName", 1)
             )
-                .withValue("sal", "Mrs.")
-                .withValue("person", new TestPrintable(Map.of("firstName", "Jane", "lastName", "Doe")))
-                .writeTo(new StringWriter()),
-            hasToString("Hello Mrs. Jane Doe.")
-        );
+        )
+            .withValue("sal", "Mrs.")
+            .withValue("person", new TestPrintable(Map.of("firstName", "Jane", "lastName", "Doe")));
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        media.writeTo(baos);
+        final String message = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(baos.toByteArray())))
+            .lines()
+            .collect(joining("\n"));
+
+        assertThat(message, hasToString("Hello Mrs. Jane Doe."));
     }
 
     @Test
     void should_format_with_collection() throws Exception {
-        assertThat(
-            new MessageMedia(new MessageFormatNamedBridge(new MessageFormat("Values are {0}."), Map.of("values", 0)))
-                .withValue("values", List.of("apples", "bananas"))
-                .writeTo(new StringWriter()),
-            hasToString("Values are apples, bananas.")
-        );
+        final MessageMedia media = new MessageMedia(
+            new MessageFormatNamedBridge(new MessageFormat("Values are {0}."), Map.of("values", 0))
+        )
+            .withValue("values", List.of("apples", "bananas"));
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        media.writeTo(baos);
+        final String message = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(baos.toByteArray())))
+            .lines()
+            .collect(joining("\n"));
+
+        assertThat(message, hasToString("Values are apples, bananas."));
     }
 
     @Test
     void should_format_with_another_messagemedia() throws Exception {
-        assertThat(
-            new MessageMedia(
-                new MessageFormatNamedBridge(
-                    new MessageFormat("Hello Mr. {0} {1}!"),
-                    Map.of("person.firstName", 0, "person.lastName", 1)
-                )
+        final MessageMedia media = new MessageMedia(
+            new MessageFormatNamedBridge(
+                new MessageFormat("Hello Mr. {0} {1}!"),
+                Map.of("person.firstName", 0, "person.lastName", 1)
             )
-                .withValue(
-                    "person",
-                    new MessageMedia(
-                        new MessageFormatNamedBridge(
-                            new MessageFormat("{0} {1}"),
-                            Map.of("firstName", 0, "lastName", 1)
-                        )
-                    )
-                        .withValue("lastName", "Doe")
-                        .withValue("firstName", "John")
+        )
+            .withValue(
+                "person",
+                new MessageMedia(
+                    new MessageFormatNamedBridge(new MessageFormat("{0} {1}"), Map.of("firstName", 0, "lastName", 1))
                 )
-                .writeTo(new StringWriter()),
-            hasToString("Hello Mr. John Doe!")
-        );
+                    .withValue("lastName", "Doe")
+                    .withValue("firstName", "John")
+            );
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        media.writeTo(baos);
+        final String message = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(baos.toByteArray())))
+            .lines()
+            .collect(joining("\n"));
+
+        assertThat(message, hasToString("Hello Mr. John Doe!"));
     }
 }


### PR DESCRIPTION
this change should allow to use also binary media to be use this interface. to create a string of a writebale it has a asString default method now. this means instead of
  `String str = writable.writeTo(new StringWriter()).toString();`
you can write
  `String str = writable.asString();`
now.
same exists to get a byte array
  `byte[] bytes = writebale.asBytes();`
as implmenter of it you must now write into a stream instead of a writer.