### PR TITLE
use bigdecimal resp. biginteger to print jsonNumbers

### DIFF
--- a/media-json-api/src/main/java/io/github/sebastiantoepfer/ddd/media/json/printable/DecimalNumberJsonMappedValue.java
+++ b/media-json-api/src/main/java/io/github/sebastiantoepfer/ddd/media/json/printable/DecimalNumberJsonMappedValue.java
@@ -3,6 +3,7 @@ package io.github.sebastiantoepfer.ddd.media.json.printable;
 import io.github.sebastiantoepfer.ddd.common.Media;
 import io.github.sebastiantoepfer.ddd.common.Printable;
 import jakarta.json.JsonNumber;
+import java.math.BigDecimal;
 
 class DecimalNumberJsonMappedValue implements JsonMappedValue {
 
@@ -23,7 +24,7 @@ class DecimalNumberJsonMappedValue implements JsonMappedValue {
     }
 
     @Override
-    public Double toValue() {
-        return value.doubleValue();
+    public BigDecimal toValue() {
+        return value.bigDecimalValue();
     }
 }

--- a/media-json-api/src/main/java/io/github/sebastiantoepfer/ddd/media/json/printable/IntegerNumberJsonMappedValue.java
+++ b/media-json-api/src/main/java/io/github/sebastiantoepfer/ddd/media/json/printable/IntegerNumberJsonMappedValue.java
@@ -3,6 +3,7 @@ package io.github.sebastiantoepfer.ddd.media.json.printable;
 import io.github.sebastiantoepfer.ddd.common.Media;
 import io.github.sebastiantoepfer.ddd.common.Printable;
 import jakarta.json.JsonNumber;
+import java.math.BigInteger;
 
 class IntegerNumberJsonMappedValue implements JsonMappedValue {
 
@@ -23,7 +24,7 @@ class IntegerNumberJsonMappedValue implements JsonMappedValue {
     }
 
     @Override
-    public Long toValue() {
-        return value.longValueExact();
+    public BigInteger toValue() {
+        return value.bigIntegerValueExact();
     }
 }

--- a/media-json-api/src/test/java/io/github/sebastiantoepfer/ddd/media/json/JsonObjectPrintableTest.java
+++ b/media-json-api/src/test/java/io/github/sebastiantoepfer/ddd/media/json/JsonObjectPrintableTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.is;
 import io.github.sebastiantoepfer.ddd.media.core.HashMapMedia;
 import jakarta.json.Json;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
 
@@ -26,7 +27,7 @@ class JsonObjectPrintableTest {
     void should_print_number_property() {
         assertThat(
             new JsonObjectPrintable(Json.createObjectBuilder().add("name", 234).build()).printOn(new HashMapMedia()),
-            hasEntry("name", 234L)
+            hasEntry("name", BigInteger.valueOf(234L))
         );
     }
 
@@ -35,7 +36,7 @@ class JsonObjectPrintableTest {
         assertThat(
             new JsonObjectPrintable(Json.createObjectBuilder().add("name", 234.27261).build())
                 .printOn(new HashMapMedia()),
-            hasEntry("name", 234.27261)
+            hasEntry("name", BigDecimal.valueOf(234.27261))
         );
     }
 
@@ -73,7 +74,7 @@ class JsonObjectPrintableTest {
                 Json.createObjectBuilder().add("name", Json.createObjectBuilder().add("test", BigDecimal.ONE)).build()
             )
                 .printOn(new HashMapMedia()),
-            (Matcher) hasEntry(is("name"), hasEntry("test", 1L))
+            (Matcher) hasEntry(is("name"), hasEntry("test", BigInteger.valueOf(1L)))
         );
     }
 


### PR DESCRIPTION
breaking change if the implementation depends on the primitive long or double. they are now biginterger and bigdecimal respectively to be more json-p compatible.